### PR TITLE
Adds null checking to data.result

### DIFF
--- a/lib/zuora.js
+++ b/lib/zuora.js
@@ -609,7 +609,7 @@ var QueryHandler = function (zuora, fields, limit, callback) {
                     that.result.push(result);
                 }
             }
-            if (undefined !== data.result.queryLocator) {
+            if (data && data.result && data.result.queryLocator) {
                 that.queryLocator = data.result.queryLocator;
             }
             that.callback.call(that, err, data);


### PR DESCRIPTION
In certain situations, data.result can equal "null" instead of "undefined" and this check covers both cases.  In our case, we had a bad field name in a query, and it was successfully parsing the fault code, but then getting a TypeError on this line because data.result was "null" not "undefined".